### PR TITLE
Ignore SPM `.build/` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ default.profraw
 # Everything without a .enc extension is ignored
 .configure-files/*
 !.configure-files/*.enc
+
+# Swift Package Manger uses this folder for CLI operations
+.build


### PR DESCRIPTION
**TL;DR**: If one runs `swift build`, SPM will generate a `.build` folder which we don't want in the repo.

**More details.** I run into a `segmentation fault` error when exporting the Simplenote macOS archive using `xcodebuild` from Xcode 15.4. This surprised me as very little has changed in the project since the last release, which obviously didn't have this problem.

I decided to verify whether the commit that faults with Xcode 15.4 exports fine in with 15.1. But the 15.1 toolchain comes with Swift 5.9 which is not compatible with this package, which uses 5.10

```
[14:25:27]: ▸ xcodebuild: error: Could not resolve package dependencies:
[14:25:27]: ▸   package 'simplenoteendpoints-swift' @ 1.0.0 is using Swift tools version 5.10.0 but the installed version is 5.9.0
```

I checked out this repo locally to drop the version and run `swift build` and `swift test` to make sure everything worked. Doing so generated the `.build/` folder and prompted me to update the `.gitignore`.

